### PR TITLE
(MODULES-2108) Update IIS, windows-feature, download-file

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,9 +12,9 @@
     {"name":"puppetlabs-powershell","version_requirement":"1.x"},
     {"name":"puppetlabs-reboot","version_requirement":"0.x"},
     {"name":"puppetlabs-acl","version_requirement":"1.x"},
-    {"name":"opentable-windowsfeature","version_requirement":"1.x"},
-    {"name":"opentable-download_file","version_requirement":"1.x"},
-    {"name":"opentable-iis","version_requirement":"1.x"}
+    {"name":"puppet-windowsfeature","version_requirement":"1.x"},
+    {"name":"puppet-download_file","version_requirement":"1.x"},
+    {"name":"puppet-iis","version_requirement":"1.x"}
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
 - All OpenTable modules have been moved to the Puppet community
   namespace, so update the references accordingly.

 - Furthermore, the last 1.3 release of the IIS module under the
   OpenTable namespace has an issue with Ruby code in the manifests
   directory that induces an OOM issue in Puppet Server.  The 1.4.1
   version of the IIS module contains a fix.