### PR TITLE
(maint) Replace ns-name with ns/name in dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,13 +8,13 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-windows",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
-    {"name":"puppetlabs-registry","version_requirement":"1.x"},
-    {"name":"puppetlabs-powershell","version_requirement":"1.x"},
-    {"name":"puppetlabs-reboot","version_requirement":"1.x"},
-    {"name":"puppetlabs-acl","version_requirement":"1.x"},
-    {"name":"puppet-windowsfeature","version_requirement":"1.x"},
-    {"name":"puppet-download_file","version_requirement":"1.x"},
-    {"name":"puppet-iis","version_requirement":"1.x"}
+    {"name":"puppetlabs/registry","version_requirement":"1.x"},
+    {"name":"puppetlabs/powershell","version_requirement":"1.x"},
+    {"name":"puppetlabs/reboot","version_requirement":"1.x"},
+    {"name":"puppetlabs/acl","version_requirement":"1.x"},
+    {"name":"puppet/windowsfeature","version_requirement":"1.x"},
+    {"name":"puppet/download_file","version_requirement":"1.x"},
+    {"name":"puppet/iis","version_requirement":"1.x"}
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
Users have reported that in current versions of the Puppet module tool when dependencies are specified in the form namespace-modulename the command `puppet module list` will complain of missing dependencies. Replacing the dependencies with namespace/modulename in the metadata.json resolves this issue.

While this is certainly a bug that should be fixed in the module tool our docs do use the namespace/modulename convention so it makes sense to change the metadata.json file here too.