### PR TITLE
(FM-4686) Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,24 @@
-##2015-12-08 - Release 2.1.1
+## 201-02-03 - Release 2.2.0
+### Summary
+
+Add DSC to the module pack.
+
+## 2015-12-08 - Release 2.1.1
 ### Summary
 
 Small release for support of newer PE versions.
 
-##2015-09-15 - Release 2.1.0
+## 2015-09-15 - Release 2.1.0
 ### Summary
 
 Add Chocolatey and Windows_Env to the module pack.
 
-##2015-07-15 - Release 2.0.1
+## 2015-07-15 - Release 2.0.1
 ### Summary
 
 Update metatata.json dependencies to use "/"" instead of "-"".
 
-##2015-06-09 - Release 2.0.0
+## 2015-06-09 - Release 2.0.0
 ### Summary
 
 Update modules to new namespace.

--- a/README.md
+++ b/README.md
@@ -15,13 +15,12 @@
 [puppet-download_file]: https://forge.puppetlabs.com/puppet/download_file
 [puppet-iis]: https://forge.puppetlabs.com/puppet/iis
 [puppet-windowsfeature]: https://forge.puppetlabs.com/puppet/windowsfeature
-
 [badgerious-windows_env]: https://forge.puppetlabs.com/badgerious/windows_env
 [chocolatey-chocolatey]: https://forge.puppetlabs.com/chocolatey/chocolatey
+
 [puppet-windows_eventlog]: https://forge.puppetlabs.com/puppet/windows_eventlog
 [puppet-sslcertificate]: https://forge.puppetlabs.com/puppet/sslcertificate
 [counsyl-windows]: https://forge.puppetlabs.com/counsyl/windows
-[ceritsc-chocolatey_sw]: https://forge.puppetlabs.com/ceritsc/chocolatey_sw
 [jriviere-windows_ad]: https://forge.puppetlabs.com/jriviere/windows_ad
 [trlinkin-domain_membership]: https://forge.puppetlabs.com/trlinkin/domain_membership
 
@@ -46,19 +45,21 @@ These are the modules available in the puppetlabs-windows pack. Full documentati
 Take note that only the modules by Puppet Labs are supported with Puppet Enterprise. The rest have been reviewed and recommended by Puppet Labs but are not eligible for [commercial support].
 
 Use Puppet on Windows to:
-- Read, create and write **registry keys** with [puppetlabs-registry].
+
+- Enforce fine-grained **access control** permissions using [puppetlabs-acl].
 - Manage **Windows PowerShell DSC** (Desired State Configuration) resources using [puppetlabs-dsc].
 - Interact with **PowerShell** through the Puppet DSL with [puppetlabs-powershell].
 - **Reboot** Windows as part of management as necessary through [puppetlabs-reboot].
-- Enforce fine-grained **access control** permissions using [puppetlabs-acl].
-- Manage Windows Server Update Service configs on client nodes [puppetlabs-wsus_client].
-- Install or remove **Windows features** with [puppet-windowsfeature].
-- Download files for use during management via [puppet-download_file].
-- Build IIS sites and virtual applications with [puppet-iis].
-- Install packages with [chocolatey-chocolatey].
-- Manage environment variables with ease with [badgerious-windows_env].
-- Soon, create and manage Microsoft SQL including databases, users and grants with the [puppetlabs-sqlserver] module (installed separately).
+- Manage **registry keys and values** with [puppetlabs-registry].
+- Specify **WSUS client configuration** (Windows Server Update Service) with [puppetlabs-wsus_client].
+- Create, edit, and remove **environment variables** with ease with [badgerious-windows_env].
+- Manage the installation of **software/packages** with [chocolatey-chocolatey].
+- **Download files** via [puppet-download_file].
+- Build **IIS sites** and **virtual applications** with [puppet-iis].
+- Add/remove **Windows features** with [puppet-windowsfeature].
 
+
+You can also create and manage Microsoft SQL including databases, users and grants with the [puppetlabs-sqlserver] module (for Puppet Enterprise customers, installed separately).
 
 ## More from the Puppet Forge
 
@@ -67,7 +68,6 @@ You can find even more great modules by [searching for windows]. Here are a few 
 - [puppet-windows_eventlog]
 - [puppet-sslcertificate]
 - [counsyl-windows]
-- [ceritsc-chocolatey_sw]
 - [jriviere-windows_ad]
 - [trlinkin-domain_membership]
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-windows",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "author": "puppetlabs",
   "summary": "Collection of Puppet modules for managing Microsoft Windows.",
   "license": "Apache-2.0",
@@ -8,17 +8,17 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-windows",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
-    {"name":"puppetlabs/registry","version_requirement":"1.x"},
+    {"name":"puppetlabs/acl","version_requirement":"1.x"},
     {"name":"puppetlabs/dsc","version_requirement":"1.x"},
     {"name":"puppetlabs/powershell","version_requirement":"1.x"},
     {"name":"puppetlabs/reboot","version_requirement":"1.x"},
-    {"name":"puppetlabs/acl","version_requirement":"1.x"},
+    {"name":"puppetlabs/registry","version_requirement":"1.x"},
     {"name":"puppetlabs/wsus_client","version_requirement":"1.x"},
-    {"name":"puppet/windowsfeature","version_requirement":"1.x"},
+    {"name":"badgerious/windows_env","version_requirement":"2.x"},
+    {"name":"chocolatey/chocolatey","version_requirement":"1.x"},
     {"name":"puppet/download_file","version_requirement":"1.x"},
     {"name":"puppet/iis","version_requirement":"1.x"},
-    {"name":"chocolatey/chocolatey","version_requirement":"1.x"},
-    {"name":"badgerious/windows_env","version_requirement":"2.x"}
+    {"name":"puppet/windowsfeature","version_requirement":"1.x"}
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
- Cleanup readme
- Update the changelog / metadata.json with version changes
- Remove ceritsc/chocolatey_sw from the readme - the module
  was originally added because the Chocolatey provider did not
  handle its own installation. Now that it does, the chocolatey_sw
  module is no longer necessary and doesn't appear to be getting
  updated

~~Depends on #15 and a rebase.~~

