### PR TITLE
Update iis dependency to 2.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
     {"name":"badgerious/windows_env","version_requirement":"2.x"},
     {"name":"chocolatey/chocolatey","version_requirement":"1.x"},
     {"name":"puppet/download_file","version_requirement":"1.x"},
-    {"name":"puppet/iis","version_requirement":"1.x"},
+    {"name":"puppet/iis","version_requirement":"2.x"},
     {"name":"puppet/windowsfeature","version_requirement":"1.x"}
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
puppet/iis shipped a 2.0.0 version in February

https://forge.puppetlabs.com/puppet/iis