### PR TITLE
(MODULES-3039) Use supported Chocolatey provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [puppet-iis]: https://forge.puppetlabs.com/puppet/iis
 [puppet-windowsfeature]: https://forge.puppetlabs.com/puppet/windowsfeature
 [badgerious-windows_env]: https://forge.puppetlabs.com/badgerious/windows_env
-[chocolatey-chocolatey]: https://forge.puppetlabs.com/chocolatey/chocolatey
+[puppetlabs-chocolatey]: https://forge.puppetlabs.com/puppetlabs/chocolatey
 
 [puppet-windows_eventlog]: https://forge.puppetlabs.com/puppet/windows_eventlog
 [puppet-sslcertificate]: https://forge.puppetlabs.com/puppet/sslcertificate

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     {"name":"puppetlabs/registry","version_requirement":"1.x"},
     {"name":"puppetlabs/wsus_client","version_requirement":"1.x"},
     {"name":"badgerious/windows_env","version_requirement":"2.x"},
-    {"name":"chocolatey/chocolatey","version_requirement":"1.x"},
+    {"name":"puppetlabs/chocolatey","version_requirement":"2.x"},
     {"name":"puppet/download_file","version_requirement":"1.x"},
     {"name":"puppet/iis","version_requirement":"2.x"},
     {"name":"puppet/windowsfeature","version_requirement":"1.x"}


### PR DESCRIPTION
Update the puppetlabs windows module pack to use the PL version instead of the Community provider