### PR TITLE
(MODULES-4804) Prepare for 4.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2017-05-03 - Release 4.0.0
+### Summary
+
+Update module to new namespace.
+
+- Puppet-Community module (`windows_env`) moved from badgerious ([MODULES-4657](https://tickets.puppetlabs.com/browse/MODULES-4657))
+- Requires --force to update if previously installed
+
 ## 2016-10-25 - Release 3.0.0
 ### Summary
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-windows",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "author": "puppetlabs",
   "summary": "Collection of Puppet modules for managing Microsoft Windows.",
   "license": "Apache-2.0",
@@ -35,10 +35,6 @@
     }
   ],
   "requirements": [
-    {
-      "name": "pe",
-      "version_requirement": ">= 3.4.0 < 2016.4.0"
-    },
     {
       "name": "puppet",
       "version_requirement": ">= 3.7.0 < 5.0.0"


### PR DESCRIPTION
This commit prepares the module for a 4.0.0 release. This commit also removes
the `pe` requirement from the metadata as it is no longer required.