### PR TITLE
(MODULES-3054) Change IIS module to supported Puppet Labs

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,12 +11,12 @@
     {"name":"puppetlabs/acl","version_requirement":"1.x"},
     {"name":"puppetlabs/chocolatey","version_requirement":"2.x"},
     {"name":"puppetlabs/dsc","version_requirement":"1.x"},
+    {"name":"puppetlabs/iis","version_requirement":"4.x"},
     {"name":"puppetlabs/powershell","version_requirement":">= 1.0.0 < 3.0.0"},
     {"name":"puppetlabs/reboot","version_requirement":"1.x"},
     {"name":"puppetlabs/registry","version_requirement":"1.x"},
     {"name":"puppetlabs/wsus_client","version_requirement":"1.x"},
     {"name":"puppet/download_file","version_requirement":">= 1.0.0 < 3.0.0"},
-    {"name":"puppet/iis","version_requirement":">= 1.0.0 < 3.0.0"},
     {"name":"puppet/windows_env","version_requirement":"2.x"},
     {"name":"puppet/windowsfeature","version_requirement":">= 1.0.0 < 3.0.0"}
   ],


### PR DESCRIPTION
Now that the PuppetLabs Supported IIS module has been released the Windows
module pack should now use that in preference to the Vox Pupli IIS modules.
This commit modifies the dependency metadata to install the puppetlabs IIS
module.