### PR TITLE
(MODULES-4271) Add Server 2016 to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -28,6 +28,7 @@
         "Server 2008 R2",
         "Server 2012",
         "Server 2012 R2",
+        "Server 2016",
         "7",
         "8.1",
         "10"


### PR DESCRIPTION
This commit adds Server 2016 to the list of supported Windows OSes.