### PR TITLE
(MODULES-7486) Prepare for v6.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2018-07-25 - Release 6.0.0
+### Summary
+
+Update module for Puppet 5 and convert to PDK format
+
+- Converted the module to PDK format ([MODULES-7047](https://tickets.puppetlabs.com/browse/MODULES-7047))
+- Added acceptance tests ([MODULES-7029](https://tickets.puppetlabs.com/browse/MODULES-7029))
+- Added Windows Server 2016 to supported operating systems ([MODULES-4271](https://tickets.puppetlabs.com/browse/MODULES-4271))
+- Update reboot module to reflect the release of version 2.0
+- Update the module and puppet versions for Puppet 5
+
 ## 2017-06-13 - Release 5.0.0
 ### Summary
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-windows",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "author": "puppetlabs",
   "summary": "Collection of Puppet modules for managing Microsoft Windows.",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/acl",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/chocolatey",
@@ -34,7 +34,7 @@
     },
     {
       "name": "puppetlabs/registry",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/wsus_client",
@@ -42,15 +42,15 @@
     },
     {
       "name": "puppet/download_file",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
+      "version_requirement": ">= 1.0.0 < 4.0.0"
     },
     {
       "name": "puppet/windows_env",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     },
     {
       "name": "puppet/windowsfeature",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
+      "version_requirement": ">= 1.0.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -71,7 +71,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.7.0 < 5.0.0"
+      "version_requirement": ">= 3.7.0 < 6.0.0"
     }
   ],
   "pdk-version": "1.6.0",


### PR DESCRIPTION
This commit updates the acl, registry, download_file, windows_env and
windowsfeature modules for Puppet 5 compatibility.

---

This commit prepares the module for v6.0.0 release.
