### PR TITLE
(MODULES-7521) Update chocolatey module to version 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Update module for Puppet 5 and convert to PDK format
 - Added Windows Server 2016 to supported operating systems ([MODULES-4271](https://tickets.puppetlabs.com/browse/MODULES-4271))
 - Update reboot module to reflect the release of version 2.0
 - Update the module and puppet versions for Puppet 5
+- Update chocolatey module to the latest ([MODULES-7521](https://tickets.puppetlabs.com/browse/MODULES-7521))
 
 ## 2017-06-13 - Release 5.0.0
 ### Summary

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/chocolatey",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/dsc",


### PR DESCRIPTION
This commit updates the dependency for the chocolatey module to support version
3.0.0, which was released back in June 2017.