### PR TITLE
(maint) Update PDK sync file

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,9 +1,44 @@
 ---
+Gemfile:
+  required:
+    ':system_tests':
+      - gem: 'puppet-module-posix-system-r#{minor_version}'
+        platforms: ruby
+      - gem: 'puppet-module-win-system-r#{minor_version}'
+        platforms:
+          - mswin
+          - mingw
+          - x64_mingw
+      - gem: beaker
+        version: '~> 3.13'
+        from_env: BEAKER_VERSION
+      - gem: beaker-abs
+        version: '~> 0.1'
+        from_env: BEAKER_ABS_VERSION
+      - gem: beaker-pe
+      - gem: beaker-hostgenerator
+        version: '>= 0.0'
+        from_env: BEAKER_HOSTGENERATOR_VERSION
+      - gem: beaker-rspec
+        version: '>= 0.0'
+        from_env: BEAKER_RSPEC_VERSION
+      - gem: beaker-testmode_switcher
+        version: '~> 0.4'
+      - gem: master_manipulator
+      - gem: puppet-blacksmith
+        version: '~> 3.4'
+
 appveyor.yml:
   unmanaged: true
 .travis.yml:
   unmanaged: true
 
+.gitlab-ci.yml:
+  delete: true
+
 Rakefile:
   requires:
     - puppet-lint/tasks/puppet-lint
+
+spec/default_facts.yml:
+  unmanaged: true

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,18 @@ group :development do
   gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
+group :system_tests do
+  gem "puppet-module-posix-system-r#{minor_version}",                                        require: false, platforms: [:ruby]
+  gem "puppet-module-win-system-r#{minor_version}",                                          require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.13')
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
+  gem "beaker-pe",                                                                           require: false
+  gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '>= 0.0')
+  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'] || '>= 0.0')
+  gem "beaker-testmode_switcher", '~> 0.4',                                                  require: false
+  gem "master_manipulator",                                                                  require: false
+  gem "puppet-blacksmith", '~> 3.4',                                                         require: false
+end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
 puppet_type = gem_type(puppet_version)

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -1,0 +1,7 @@
+# Use default_module_facts.yml for module specific facts.
+#
+# Facts specified here will override the values provided by rspec-puppet-facts.
+---
+ipaddress: "172.16.254.254"
+is_pe: false
+macaddress: "AA:AA:AA:AA:AA:AA"


### PR DESCRIPTION
Previously the PDK sync file was missing the system_tests section which was
causing acceptance test failures because beaker was not installed.  This commit;

* Adds the expected Gemfile sections for the system tests

* Converts the Gemfile back to LF line endings as they accidentally changed to
  CRLF during PDK convert

* Updates the .sync.yml file to delete the git lab config as it is not required

* Updates the .sync.yml file to not manage the default facts file as it is not
  used