### PR TITLE
(MODULES-7846) Remove maximum Puppet version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -71,7 +71,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.7.0 < 5.0.0"
+      "version_requirement": ">= 3.7.0"
     }
   ],
   "pdk-version": "1.6.0",


### PR DESCRIPTION
As the puppetlabs-windows module is actually just a meta-module which pulls in
dependent modules it doesn't really need a maximum puppet version.  This commit
removes the max restriction, but still keeps the minimum.